### PR TITLE
Reword "crazy configurations"

### DIFF
--- a/src/Table.elm
+++ b/src/Table.elm
@@ -25,7 +25,7 @@ I recommend checking out the [examples][] to get a feel for how it works.
 
 @docs view
 
-# Configuration
+# Basic Configuration
 
 @docs config, stringColumn, intColumn, floatColumn
 
@@ -34,12 +34,11 @@ I recommend checking out the [examples][] to get a feel for how it works.
 @docs State, initialSort
 
 
-# Crazy Customization
+# Extended Customization
 
-If you are new to this library, you can probably stop reading here. After this
+So far we have presented the most common customization options. After this
 point are a bunch of ways to customize your table further. If it does not
-provide what you need, you may just want to write a custom table yourself. It
-is not that crazy.
+provide what you need, you may just want to write a custom table yourself.
 
 ## Custom Columns
 


### PR DESCRIPTION
This is all in the public API, so it's evidently not crazy. Crazy is also a fairly emotionally loaded word which doesn't belong in documentation.

https://en.oxforddictionaries.com/definition/crazy writes:

> crazy
> 1. especially as manifested in wild or aggressive behaviour.
> 1.1 Extremely angry.
> 1.2 Foolish.
> 2. Extremely enthusiastic.
> 3. (of an angle) appearing absurdly out of place or unlikely.

Using a custom column is none of these. This irks me every time I read this documentation, which should be neutral.